### PR TITLE
Add classnames support for EditorsKit plugin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -110,6 +110,9 @@ require get_parent_theme_file_path( 'inc/customizer/fonts.php' );
 // Jetpack specific functionality.
 require get_parent_theme_file_path( 'inc/plugins/jetpack.php' );
 
+// EditorsKit specific functionality.
+require get_parent_theme_file_path( 'inc/plugins/editorskit.php' );
+
 /**
  * Load WooCommerce compatibility file.
  */

--- a/inc/plugins/editorskit.php
+++ b/inc/plugins/editorskit.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Add Support for EditorsKit Plugin
+ *
+ * @package Jarvis
+ * @subpackage EditorsKit
+ * @author Jeffrey Carandang <jeffreycarandang.com>
+ * @link https://editorskit.com/
+ * @license http://www.gnu.org/licenses/gpl-2.0.html GNU Public License
+ */
+
+/**
+ * Add classname suggestions
+ *
+ * @param array $classes default classnames
+ * @return array Add theme utility classes
+ */
+function editorskit_jarvis_classnames( $classes ){
+
+	$theme_classes = array(
+		'block-info',
+		'block-help',
+		'block-alert',
+		'block-success',
+		'block-error',
+		'block-announcement',
+		'block-intro',
+		'block-border',
+		'block-border-dashed',
+	);
+
+	$classes = array_merge( $classes, $theme_classes );
+
+	return $classes;
+}
+
+add_filter( 'editorskit_block_editor_classnames', 'editorskit_jarvis_classnames', 10, 3 );


### PR DESCRIPTION
I've added the array list of the theme's utility classes support for EditorsKit plugin.